### PR TITLE
Do not recompress JPG file if reduction is less than 1%

### DIFF
--- a/optimize_images/img_optimize_jpg.py
+++ b/optimize_images/img_optimize_jpg.py
@@ -101,7 +101,7 @@ def optimize_jpg(t: Task) -> TaskResult:
 
     # Only replace the original file if compression did save any space
     final_size = os.path.getsize(temp_file_path)
-    if t.no_size_comparison or (orig_size - final_size > 0):
+    if t.no_size_comparison or ((orig_size - final_size > 0) and (final_size / orig_size * 100 < 99)):
         shutil.move(temp_file_path, os.path.expanduser(t.src_path))
         was_optimized = True
     else:


### PR DESCRIPTION
Sometimes file is already optimized by this or other tool. In this case it may be recompressed with very small gain, around few hundred bytes. But it is harmful to unnecessary recode JPEGs as due to their lossless nature they gradually lose in quality with every save.
It's not a problem with lossless PNG files.
This patch instructs JPEG optimizer to skip optimization if it's gain is smaller than 1%.

