### PR TITLE
Added the ability to import this program into other Python programs

### DIFF
--- a/optimize_images/__init__.py
+++ b/optimize_images/__init__.py
@@ -1,1 +1,2 @@
 __version__ = '1.4.1a'
+from optimize_images.__main__ import worker

--- a/optimize_images/__init__.py
+++ b/optimize_images/__init__.py
@@ -1,2 +1,2 @@
 __version__ = '1.4.1a'
-from optimize_images.__main__ import optimizer
+from optimize_images.api import optimizer

--- a/optimize_images/__init__.py
+++ b/optimize_images/__init__.py
@@ -1,2 +1,2 @@
 __version__ = '1.4.1a'
-from optimize_images.__main__ import worker
+from optimize_images.__main__ import optimizer

--- a/optimize_images/__main__.py
+++ b/optimize_images/__main__.py
@@ -62,9 +62,9 @@ from optimize_images.watch import watch_for_new_files
 
 def main():
     args = get_args()
-    worker(*args)
+    optimizer(*args)
 
-def worker(src_path, watch_dir=False, recursive=True, quality=80, remove_transparency=False,
+def optimizer(src_path, watch_dir=False, recursive=True, quality=80, remove_transparency=False,
      reduce_colors=False, max_colors=256, max_w=0, max_h=0, keep_exif=False, convert_all=False, 
      conv_big=False, force_del=False, bg_color=(255, 255, 255), grayscale=False,
      ignore_size_comparison=False, fast_mode=False, jobs=0):

--- a/optimize_images/__main__.py
+++ b/optimize_images/__main__.py
@@ -64,10 +64,10 @@ def main():
     args = get_args()
     optimizer(*args)
 
-def optimizer(src_path, watch_dir=False, recursive=True, quality=80, remove_transparency=False,
-     reduce_colors=False, max_colors=256, max_w=0, max_h=0, keep_exif=False, convert_all=False, 
-     conv_big=False, force_del=False, bg_color=(255, 255, 255), grayscale=False,
-     ignore_size_comparison=False, fast_mode=False, jobs=0):
+def optimizer(src_path, watch_dir, recursive, quality, remove_transparency,
+     reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all, 
+     conv_big, force_del, bg_color, grayscale,
+     ignore_size_comparison, fast_mode, jobs):
     appstart = timer()
     line_width, our_pool_executor, workers = adjust_for_platform()
     if jobs != 0:

--- a/optimize_images/__main__.py
+++ b/optimize_images/__main__.py
@@ -61,14 +61,15 @@ from optimize_images.watch import watch_for_new_files
 
 
 def main():
+    args = get_args()
+    worker(*args)
+
+def worker(src_path, watch_dir=False, recursive=True, quality=80, remove_transparency=False,
+     reduce_colors=False, max_colors=256, max_w=0, max_h=0, keep_exif=False, convert_all=False, 
+     conv_big=False, force_del=False, bg_color=(255, 255, 255), grayscale=False,
+     ignore_size_comparison=False, fast_mode=False, jobs=0):
     appstart = timer()
     line_width, our_pool_executor, workers = adjust_for_platform()
-
-    (watch_dir, src_path, recursive, quality, remove_transparency,
-     reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all, conv_big,
-     force_del, bg_color, grayscale, ignore_size_comparison, fast_mode, jobs) \
-        = get_args()
-
     if jobs != 0:
         workers = jobs
 

--- a/optimize_images/api.py
+++ b/optimize_images/api.py
@@ -1,0 +1,9 @@
+def optimizer(src_path, watch_dir=False, recursive=True, quality=80, remove_transparency=False,
+     reduce_colors=False, max_colors=256, max_w=0, max_h=0, keep_exif=False, convert_all=False,
+     conv_big=False, force_del=False, bg_color=(255, 255, 255), grayscale=False,
+     ignore_size_comparison=False, fast_mode=False, jobs=0):
+    from optimize_images.__main__ import optimizer as app
+    app(src_path, watch_dir, recursive, quality, remove_transparency,
+     reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all,
+     conv_big, force_del, bg_color, grayscale,
+     ignore_size_comparison, fast_mode, jobs)

--- a/optimize_images/api.py
+++ b/optimize_images/api.py
@@ -1,9 +1,10 @@
 def optimizer(src_path, watch_dir=False, recursive=True, quality=80, remove_transparency=False,
-     reduce_colors=False, max_colors=256, max_w=0, max_h=0, keep_exif=False, convert_all=False,
-     conv_big=False, force_del=False, bg_color=(255, 255, 255), grayscale=False,
-     ignore_size_comparison=False, fast_mode=False, jobs=0):
+              reduce_colors=False, max_colors=256, max_w=0, max_h=0, keep_exif=False,
+              convert_all=False, conv_big=False, force_del=False, bg_color=(255, 255, 255),
+              grayscale=False, ignore_size_comparison=False, fast_mode=False, jobs=0):
+
     from optimize_images.__main__ import optimizer as app
-    app(src_path, watch_dir, recursive, quality, remove_transparency,
-     reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all,
-     conv_big, force_del, bg_color, grayscale,
-     ignore_size_comparison, fast_mode, jobs)
+
+    app(src_path, watch_dir, recursive, quality, remove_transparency, conv_big,
+        force_del, reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all,
+        bg_color, grayscale, ignore_size_comparison, fast_mode, jobs)

--- a/optimize_images/argument_parser.py
+++ b/optimize_images/argument_parser.py
@@ -248,7 +248,7 @@ def get_args():
               "bright red you can use: '-bg 255 0 0' or '-hbg #FF0000'.\n\n"
         parser.exit(status=0, message=msg)
 
-    return watch_dir, src_path, recursive, quality, args.remove_transparency, \
+    return src_path, watch_dir, recursive, quality, args.remove_transparency, \
            args.reduce_colors, args.max_colors, args.max_width, args.max_height, \
            args.keep_exif, args.convert_all, args.convert_big, args.force_delete, \
            bg_color, args.grayscale, args.no_comparison, args.fast_mode, \

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,9 @@ setup(name='optimize-images',
                'seo-optimization website-performance cli recursive non-recursive',
 
       install_requires=[
-          'piexif==1.1.3',
+          'piexif>=1.1.3',
+          'Pillow>=8.0.01',
+          'watchdog>=0.10.3',
       ],
 
       entry_points={


### PR DESCRIPTION
_I closed the [previous pull request](https://github.com/victordomingos/optimize-images/pull/32) because optimizer better than worker (function name)_

## Usage
### options
```txt
src_path, watch_dir, recursive, quality, remove_transparency, reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all, conv_big, force_del, bg_color, grayscale, ignore_size_comparison, fast_mode, jobs
```

### example 1
```python
from optimize_images  import optimizer
optimizer("path/to/folder", quality=40)
```

### example 2
```python
from optimize_images  import optimizer
optimizer("path/to/image", max_w=1000, max_h=700)
```

---

I changed the order of the returning values of **'get_args'** _(in argument_parser.py)_ so that the **'get_args()'** _(in main.py)_ return values were coded to be tuple type to the 'args' variable. It is now easier to call **'worker'** function without changing the order of values.

---

Changed init.py and now user can import **'worker'** without mentioning like this.
```python
from optimize_images.api  import optimizer
```
after changed the init.py
```python
from optimize_images  import optimizer
```