### PR TITLE
Added optional flags to control the output

### DIFF
--- a/docs/docs_EN.md
+++ b/docs/docs_EN.md
@@ -34,6 +34,7 @@ and the features depending on them should be treated as optional.
        - [Fast mode](#fast-mode)
        - [Watch directory for new files](#watch-directory-for-new-files)
        - [Maximum number of simultaneous jobs](#maximum-number-of-simultaneous-jobs)
+       - [Output configuration](#output-configuration)
    * [Format specific options](#format-specific-options)
        - [JPEG](#jpeg)
           - [Quality](#quality)
@@ -344,6 +345,36 @@ the system.
 optimize-images -jobs 16 ./
 ```
 
+#### Output configuration
+
+In order to specify what to output, you can use these optional flags:
+
+##### Quiet Mode
+
+With the `--quiet` flag, you'll not see any output except form error messages and exceptions during the optimization.
+
+```
+optimize-images --quiet ./
+```
+
+##### Only Summary
+
+With this flag, you will not see any output during the optimization and only see the summary when finished.
+
+```
+optimize-images --only-summary ./
+```
+
+##### Show only the progress
+
+This will only show the overall progress and not the optimization result of every file.
+
+```
+$ optimize-images --only-progress ./
+... 
+[14.0s 57.1%] ✅ 18 🔴 68, saved 44.1 MB
+...
+```
 
 ### Format specific options:
 

--- a/docs/docs_PT.md
+++ b/docs/docs_PT.md
@@ -34,6 +34,7 @@ como opcionais, tais como as funcionalidades que deles dependam.
        - [Modo rápido](#modo-rápido)
        - [Monitorizar pasta pela criação de novos ficheiros](#monitorizar-pasta-pela-criação-de-novos-ficheiros)
        - [Número máximo de tarefas em simultâneo](#número-máximo-de-tarefas-em-simultâneo)
+       - [Configuração de saída](#configuração-de-saída)
    * [Opções específicas para cada formato](#opções-específicas-para-cada-formato)
        - [JPEG](#jpeg)
           - [Qualidade](#qualidade)
@@ -371,6 +372,37 @@ presentes no sistema.
 
 ```
 optimize-images -jobs 16 ./
+```
+
+#### Configuração de saída
+
+A fim de especificar o que deve produzir, pode utilizar estas bandeiras opcionais:
+
+##### Modo Silencioso
+
+Com a bandeira `--quiet`, não verá qualquer saída excepto mensagens de erro de forma e excepções durante a optimização.
+
+```
+optimize-images --quiet ./
+```
+
+##### Mostrar apenas o resumo
+
+Com esta bandeira, não verá nenhuma saída durante a optmização e só verá o resumo quando terminar.
+
+```
+optimize-images --only-summary ./
+```
+
+##### Mostrar apenas o progresso
+
+Isto apenas mostrará o progresso geral e não o resultado da optimização de cada ficheiro.
+
+```
+$ optimize-images --only-progress ./
+... 
+[14.0s 57.1%] ✅ 18 🔴 68, saved 44.1 MB
+...
 ```
 
 

--- a/optimize_images/__main__.py
+++ b/optimize_images/__main__.py
@@ -50,10 +50,9 @@ except ImportError:
     sys.exit()
 
 from timeit import default_timer as timer
-from math import floor
 
 from optimize_images.file_utils import search_images
-from optimize_images.data_structures import Task
+from optimize_images.data_structures import OutputConfiguration, Task
 from optimize_images.do_optimization import do_optimization
 from optimize_images.platforms import adjust_for_platform, IconGenerator
 from optimize_images.argument_parser import get_args
@@ -69,15 +68,18 @@ def count_gen(gen):
 
 def optimize_batch(src_path, watch_dir, recursive, quality, remove_transparency,
                    reduce_colors, max_colors, max_w, max_h, keep_exif, convert_all,
-                   conv_big, force_del, bg_color, grayscale,
-                   ignore_size_comparison, fast_mode, jobs, only_summary):
+                   conv_big, force_del, bg_color, grayscale, ignore_size_comparison, 
+                   fast_mode, jobs, only_summary, only_progress, quiet_mode):
     appstart = timer()
     line_width, our_pool_executor, workers = adjust_for_platform()
+    output_config = OutputConfiguration(only_summary, only_progress, quiet_mode)
+
     if jobs != 0:
         workers = jobs
 
     found_files = 0
     optimized_files = 0
+    skipped_files = 0
     total_src_size = 0
     total_bytes_saved = 0
 
@@ -89,23 +91,25 @@ def optimize_batch(src_path, watch_dir, recursive, quality, remove_transparency,
         watch_task = Task(src_path, quality, remove_transparency, reduce_colors,
                           max_colors, max_w, max_h, keep_exif, convert_all,
                           conv_big, force_del, bg_color, grayscale,
-                          ignore_size_comparison, fast_mode, only_summary)
+                          ignore_size_comparison, fast_mode, output_config)
 
         watch_for_new_files(watch_task)
         return
 
     # Optimize all images in a directory
     elif os.path.isdir(src_path):
-        icons = IconGenerator()
-        recursion_txt = 'Recursively searching' if recursive else 'Searching'
-        opt_msg = 'and optimizing image files'
-        exif_txt = '(keeping exif data) ' if keep_exif else ''
-        print(f"\n{recursion_txt} {opt_msg} {exif_txt}in:\n{src_path}\n")
+
+        if not output_config.quiet_mode:
+            icons = IconGenerator()
+            recursion_txt = 'Recursively searching' if recursive else 'Searching'
+            opt_msg = 'and optimizing image files'
+            exif_txt = '(keeping exif data) ' if keep_exif else ''
+            print(f"\n{recursion_txt} {opt_msg} {exif_txt}in:\n{src_path}\n")
 
         tasks = (Task(img_path, quality, remove_transparency, reduce_colors,
                       max_colors, max_w, max_h, keep_exif, convert_all, conv_big,
                       force_del, bg_color, grayscale, ignore_size_comparison, fast_mode,
-                      only_summary)
+                      output_config)
                  for img_path in search_images(src_path, recursive=recursive))
 
         num_images, tasks = count_gen(tasks)
@@ -119,12 +123,19 @@ def optimize_batch(src_path, watch_dir, recursive, quality, remove_transparency,
                     if result.was_optimized:
                         optimized_files += 1
                         total_bytes_saved += result.orig_size - result.final_size
-                    show_file_status(result, line_width, icons)
+                    else:
+                        skipped_files += 1
 
-                    cur_time_passed = round(timer() - appstart)
-                    perc_done = found_files / num_images * 100
-                    message = f"[{cur_time_passed:.1f}s {perc_done:.1f}%] {icons.optimized} {optimized_files} images, saved {human(total_bytes_saved)}"
-                    print(message, end='\r')
+                    if result.output_config.quiet_mode:
+                        continue
+
+                    if result.output_config.show_overall_progress:
+                        cur_time_passed = round(timer() - appstart)
+                        perc_done = found_files / num_images * 100
+                        message = f"[{cur_time_passed:.1f}s {perc_done:.1f}%] {icons.optimized} {optimized_files} {icons.skipped} {skipped_files}, saved {human(total_bytes_saved)}"
+                        print(message, end='\r')
+                    else:
+                        show_file_status(result, line_width, icons)
                     
             except concurrent.futures.process.BrokenProcessPool as bppex:
                 show_img_exception(bppex, current_img)
@@ -134,19 +145,22 @@ def optimize_batch(src_path, watch_dir, recursive, quality, remove_transparency,
 
     # Optimize a single image
     elif os.path.isfile(src_path) and '~temp~' not in src_path:
-        icons = IconGenerator()
         found_files += 1
 
         img_task = Task(src_path, quality, remove_transparency, reduce_colors,
                         max_colors, max_w, max_h, keep_exif, convert_all, conv_big,
-                        force_del, bg_color, grayscale, ignore_size_comparison, fast_mode, only_summary)
+                        force_del, bg_color, grayscale, ignore_size_comparison, fast_mode, 
+                        output_config)
 
         result = do_optimization(img_task)
         total_src_size = result.orig_size
         if result.was_optimized:
             optimized_files = 1
             total_bytes_saved = result.orig_size - result.final_size
-        show_file_status(result, line_width, icons)
+        
+        if not result.output_config.quiet_mode:
+            icons = IconGenerator()
+            show_file_status(result, line_width, icons)
     else:
         msg = "\nNo image files were found. Please enter a valid path to the " \
               "image file or the folder containing any images to be processed."
@@ -155,7 +169,7 @@ def optimize_batch(src_path, watch_dir, recursive, quality, remove_transparency,
     if found_files:
         time_passed = timer() - appstart
         show_final_report(found_files, optimized_files, total_src_size,
-                          total_bytes_saved, time_passed)
+                          total_bytes_saved, time_passed, output_config)
     else:
         msg = "\nNo supported image files were found in the specified directory."
         raise OIImagesNotFoundError(msg)

--- a/optimize_images/argument_parser.py
+++ b/optimize_images/argument_parser.py
@@ -124,6 +124,9 @@ def get_args():
               'finish faster.'
     general_group.add_argument('-fm', '--fast-mode', action='store_true', help=fm_help)
 
+    only_summary_help = 'Show only the summary'
+    general_group.add_argument('-os', '--only-summary', action='store_false', help=only_summary_help)
+
     jpg_msg = 'The following options apply only to JPEG image files.'
     jpg_group = parser.add_argument_group(
         'JPEG specific options'.upper(), description=jpg_msg)
@@ -252,4 +255,4 @@ def get_args():
            args.reduce_colors, args.max_colors, args.max_width, args.max_height, \
            args.keep_exif, args.convert_all, args.convert_big, args.force_delete, \
            bg_color, args.grayscale, args.no_comparison, args.fast_mode, \
-           args.jobs
+           args.jobs, args.only_summary

--- a/optimize_images/argument_parser.py
+++ b/optimize_images/argument_parser.py
@@ -93,6 +93,15 @@ def get_args():
     parser.add_argument('-jobs', dest="jobs",
                         type=int, default=0, help=jobs_help)
 
+    only_summary_help = 'Show only the summary'
+    parser.add_argument('--only-summary', action='store_true', help=only_summary_help)
+
+    only_progress_help = 'Show only the current progress'
+    parser.add_argument('--only-progress', action='store_true', help=only_progress_help)
+
+    quiet_help = 'Quiet mode, output nothing'
+    parser.add_argument('--quiet', action='store_true', help=quiet_help)
+
     general_msg = 'These options will be applied individually to each ' \
                   'image being processed, independently of its format.'
     general_group = parser.add_argument_group(
@@ -123,9 +132,6 @@ def get_args():
               'PNG images or variable JPEG quality setting) in order to ' \
               'finish faster.'
     general_group.add_argument('-fm', '--fast-mode', action='store_true', help=fm_help)
-
-    only_summary_help = 'Show only the summary'
-    general_group.add_argument('-os', '--only-summary', action='store_false', help=only_summary_help)
 
     jpg_msg = 'The following options apply only to JPEG image files.'
     jpg_group = parser.add_argument_group(
@@ -255,4 +261,4 @@ def get_args():
            args.reduce_colors, args.max_colors, args.max_width, args.max_height, \
            args.keep_exif, args.convert_all, args.convert_big, args.force_delete, \
            bg_color, args.grayscale, args.no_comparison, args.fast_mode, \
-           args.jobs, args.only_summary
+           args.jobs, args.only_summary, args.only_progress, args.quiet

--- a/optimize_images/data_structures.py
+++ b/optimize_images/data_structures.py
@@ -23,6 +23,7 @@ class Task(NamedTuple):
     grayscale: bool
     no_size_comparison: bool
     fast_mode: bool
+    only_summary: bool
 
 
 class TaskResult(NamedTuple):
@@ -39,3 +40,4 @@ class TaskResult(NamedTuple):
     was_downsized: bool
     had_exif: bool
     has_exif: bool
+    only_summary: bool

--- a/optimize_images/data_structures.py
+++ b/optimize_images/data_structures.py
@@ -6,6 +6,10 @@ from typing import NamedTuple, Tuple, NewType
 PPoolExType = NewType('PPoolExType', concurrent.futures.ProcessPoolExecutor)
 TPoolExType = NewType('TPoolExType', concurrent.futures.ThreadPoolExecutor)
 
+class OutputConfiguration(NamedTuple):
+    show_only_summary: bool
+    show_overall_progress: bool
+    quiet_mode: bool
 
 class Task(NamedTuple):
     src_path: str
@@ -23,7 +27,7 @@ class Task(NamedTuple):
     grayscale: bool
     no_size_comparison: bool
     fast_mode: bool
-    only_summary: bool
+    output_config: OutputConfiguration
 
 
 class TaskResult(NamedTuple):
@@ -40,4 +44,4 @@ class TaskResult(NamedTuple):
     was_downsized: bool
     had_exif: bool
     has_exif: bool
-    only_summary: bool
+    output_config: OutputConfiguration

--- a/optimize_images/do_optimization.py
+++ b/optimize_images/do_optimization.py
@@ -47,7 +47,7 @@ def do_optimization(task: Task) -> TaskResult:
                           was_downsized=False,
                           had_exif=False,
                           has_exif=False,
-                          only_summary=task.only_summary)
+                          output_config=task.output_config)
 
     # TODO: improve method of image format detection (what should happen if the
     #       file extension does not match the image content's format? Maybe we
@@ -74,4 +74,4 @@ def do_optimization(task: Task) -> TaskResult:
                       was_downsized=False,
                       had_exif=had_exif,
                       has_exif=had_exif,
-                      only_summary=task.only_summary)
+                      output_config=task.output_config)

--- a/optimize_images/do_optimization.py
+++ b/optimize_images/do_optimization.py
@@ -46,7 +46,8 @@ def do_optimization(task: Task) -> TaskResult:
                           was_optimized=False,
                           was_downsized=False,
                           had_exif=False,
-                          has_exif=False)
+                          has_exif=False,
+                          only_summary=task.only_summary)
 
     # TODO: improve method of image format detection (what should happen if the
     #       file extension does not match the image content's format? Maybe we
@@ -72,4 +73,5 @@ def do_optimization(task: Task) -> TaskResult:
                       was_optimized=False,
                       was_downsized=False,
                       had_exif=had_exif,
-                      has_exif=had_exif)
+                      has_exif=had_exif,
+                      only_summary=task.only_summary)

--- a/optimize_images/img_optimize_jpg.py
+++ b/optimize_images/img_optimize_jpg.py
@@ -98,4 +98,4 @@ def optimize_jpg(task: Task) -> TaskResult:
     return TaskResult(task.src_path, orig_format, result_format, orig_mode,
                       img_mode, orig_colors, final_colors, orig_size,
                       final_size, was_optimized, was_downsized, had_exif,
-                      has_exif, task.only_summary)
+                      has_exif, task.output_config)

--- a/optimize_images/img_optimize_jpg.py
+++ b/optimize_images/img_optimize_jpg.py
@@ -98,4 +98,4 @@ def optimize_jpg(task: Task) -> TaskResult:
     return TaskResult(task.src_path, orig_format, result_format, orig_mode,
                       img_mode, orig_colors, final_colors, orig_size,
                       final_size, was_optimized, was_downsized, had_exif,
-                      has_exif)
+                      has_exif, task.only_summary)

--- a/optimize_images/img_optimize_png.py
+++ b/optimize_images/img_optimize_png.py
@@ -87,7 +87,7 @@ def optimize_png(task: Task) -> TaskResult:
                           orig_mode, img_mode, orig_colors, final_colors,
                           orig_size, final_size, was_optimized,
                           was_downsized, had_exif, has_exif,
-                          task.only_summary)
+                          task.output_config)
 
     # if PNG and user didn't ask for PNG to JPEG conversion, do this instead.
     else:
@@ -128,4 +128,4 @@ def optimize_png(task: Task) -> TaskResult:
         return TaskResult(task.src_path, orig_format, result_format, orig_mode,
                           img_mode, orig_colors, final_colors, orig_size,
                           final_size, was_optimized, was_downsized, had_exif,
-                          has_exif, task.only_summary)
+                          has_exif, task.output_config)

--- a/optimize_images/img_optimize_png.py
+++ b/optimize_images/img_optimize_png.py
@@ -86,7 +86,8 @@ def optimize_png(task: Task) -> TaskResult:
         return TaskResult(task.src_path, orig_format, result_format,
                           orig_mode, img_mode, orig_colors, final_colors,
                           orig_size, final_size, was_optimized,
-                          was_downsized, had_exif, has_exif)
+                          was_downsized, had_exif, has_exif,
+                          task.only_summary)
 
     # if PNG and user didn't ask for PNG to JPEG conversion, do this instead.
     else:
@@ -127,4 +128,4 @@ def optimize_png(task: Task) -> TaskResult:
         return TaskResult(task.src_path, orig_format, result_format, orig_mode,
                           img_mode, orig_colors, final_colors, orig_size,
                           final_size, was_optimized, was_downsized, had_exif,
-                          has_exif)
+                          has_exif, task.only_summary)

--- a/optimize_images/reporting.py
+++ b/optimize_images/reporting.py
@@ -97,7 +97,7 @@ def show_final_report(found_files: int,
     report += f"\n   Optimized {optimized_files} files." \
         f"\n   Average savings: {human(average)} per optimized file" \
         f"\n   Total space saved: {human(bytes_saved)} / {percent:.1f}%\n"
-    print(report, end='\r')
+    print(report)
 
 
 def show_img_exception(exception: Exception, image_path: str, details: str = '') -> None:

--- a/optimize_images/reporting.py
+++ b/optimize_images/reporting.py
@@ -20,6 +20,9 @@ def human(number: int, suffix='B') -> str:
 
 
 def show_file_status(result: TaskResult, line_width: int, icons: IconGenerator):
+    if result.only_summary:
+        return
+    
     if result.was_optimized:
         short_img = result.img[-(line_width - 17):].ljust(line_width - 17)
         percent = 100 - (result.final_size / result.orig_size * 100)
@@ -87,7 +90,7 @@ def show_final_report(found_files: int,
     report += f"\n   Optimized {optimized_files} files." \
               f"\n   Average savings: {human(average)} per optimized file" \
               f"\n   Total space saved: {human(bytes_saved)} / {percent:.1f}%\n"
-    print(report)
+    print(report, end='\r')
 
 
 def show_img_exception(exception: Exception, image_path: str, details: str = '') -> None:

--- a/optimize_images/watch.py
+++ b/optimize_images/watch.py
@@ -9,7 +9,7 @@ except ImportError:
     print("Watchdog is not available.")
     exit(1)
 
-from optimize_images.data_structures import Task, TaskResult
+from optimize_images.data_structures import OutputConfiguration, Task, TaskResult
 from optimize_images.do_optimization import do_optimization
 from optimize_images.reporting import show_file_status, show_final_report
 from optimize_images.platforms import adjust_for_platform, IconGenerator
@@ -53,7 +53,7 @@ class OptimizeImageEventHandler(FileSystemEventHandler):
                         task.max_h, task.keep_exif, task.convert_all,
                         task.conv_big, task.force_del, task.bg_color,
                         task.grayscale, task.no_size_comparison, task.fast_mode,
-                        task.only_summary)
+                        task.output_config)
 
         result: TaskResult = do_optimization(img_task)
         self.total_src_size += result.orig_size
@@ -96,6 +96,7 @@ def watch_for_new_files(task: Task):
                           event_handler.optimized_files,
                           event_handler.total_src_size,
                           event_handler.total_bytes_saved,
-                          -1)
+                          -1,
+                          OutputConfiguration(False, False, False))
     else:
         print("No files were processed.\n")

--- a/optimize_images/watch.py
+++ b/optimize_images/watch.py
@@ -52,7 +52,8 @@ class OptimizeImageEventHandler(FileSystemEventHandler):
                         task.reduce_colors, task.max_colors, task.max_w,
                         task.max_h, task.keep_exif, task.convert_all,
                         task.conv_big, task.force_del, task.bg_color,
-                        task.grayscale, task.no_size_comparison, task.fast_mode)
+                        task.grayscale, task.no_size_comparison, task.fast_mode,
+                        task.only_summary)
 
         result: TaskResult = do_optimization(img_task)
         self.total_src_size += result.orig_size

--- a/tests/rapid-test.sh
+++ b/tests/rapid-test.sh
@@ -6,4 +6,4 @@ unzip 2.pelican_output.zip
 unzip 3.by-type.zip
 unzip 4.test-PNG.zip
 clear
-/usr/bin/time -lp python3 -m optimize_images test-images
+/usr/bin/time -lp python3 -m optimize_images test-images $@


### PR DESCRIPTION
I've added 3 optional flags to control the output of the tool:

## Quiet Mode

When the `--quiet` flag is given, no output will be shown (except for exceptions)

## Show the overall progress

With the `--only-progress` flag, the optimization of each file will not be printed out but a interactive (means the line will be overridden) overall progress will be shown with the following informations:
* Time since start
* Percentage done
* Number of optimized images
* Number of skipped images
* Bytes saved so far (human readable)

It looks like this:
![optimize-images-progress](https://user-images.githubusercontent.com/153910/134649377-89c64a08-ea65-4967-b178-ed2d1ee5ece7.png)

## Show only the summary

With the `--only-summary` flag only the summary will be shown at the end and will hide the output during the optimization

----

Unfortunately, I don't speak Portuguese, so I translated the documentation at `docs/docs_PT.md` using DeepL. I don't know how accurate it is, so I'll be happy to correct anything that is wrong or reads funny.

