### PR TITLE
Fix keep EXIF data -ke / --keep-exif with BytesIO buffer

### DIFF
--- a/optimize_images/img_optimize_jpg.py
+++ b/optimize_images/img_optimize_jpg.py
@@ -77,7 +77,11 @@ def optimize_jpg(task: Task) -> TaskResult:
 
     if task.keep_exif and had_exif:
         try:
-            piexif.transplant(os.path.expanduser(task.src_path), tmp_buffer)
+            tmp_buffer_exif = BytesIO()
+            piexif.transplant(os.path.expanduser(task.src_path),
+                              tmp_buffer.getbuffer(), new_file=tmp_buffer_exif)
+            tmp_buffer.close()
+            tmp_buffer = tmp_buffer_exif
             has_exif = True
         except ValueError:
             has_exif = False


### PR DESCRIPTION
As mentioned in #40 EXIF data is destroyed even when using the -ke flag. This is due to piexif.transplant expecting a subscriptable object (usually file path) which a BytesIO buffer itself is not. This is fixed by letting transplant use the buffer as an array and copying the resulting image into a new buffer which then replaces the old one.

This does not affect performance in any meaningful way, here are some Benchmarks on 50 giant (9mb) jpgs:
 - New and correctly working:
    - Processed 50 files (320.2 MB) in 2.7s (`18.3 f/s`).
    - python -m optimize_images ./conv -ke  21.77s user 1.02s system 805% cpu `2.829` total

- Old with broken EXIF
    - Processed 50 files (320.2 MB) in 2.7s (`18.2 f/s`).
    - python -m optimize_images ./conv -ke  21.69s user 1.08s system 806% cpu `2.823` total

- Old without '-ke' parameter
    - Processed 50 files (320.2 MB) in 2.7s (`18.6 f/s`).
    - python -m optimize_images ./conv  21.66s user 0.90s system 821% cpu `2.747` total